### PR TITLE
[BUGFIX] Fix detection of argument value in CompileWithContentArgumentAndRenderStatic trait

### DIFF
--- a/src/Core/ViewHelper/Traits/CompileWithContentArgumentAndRenderStatic.php
+++ b/src/Core/ViewHelper/Traits/CompileWithContentArgumentAndRenderStatic.php
@@ -75,7 +75,7 @@ trait CompileWithContentArgumentAndRenderStatic
         );
         $contentArgumentName = $this->resolveContentArgumentName();
         $initializationPhpCode .= sprintf(
-            '%s = %s[\'%s\'] ? function() use (%s) { return %s[\'%s\']; } : %s;',
+            '%s = (%s[\'%s\'] !== NULL) ? function() use (%s) { return %s[\'%s\']; } : %s;',
             $closureName,
             $argumentsName,
             $contentArgumentName,


### PR DESCRIPTION
Instead of checking for a "truethy" argument value do a strict not null comparison.